### PR TITLE
Enable native mysql auth

### DIFF
--- a/src/mysql-8/values.yml
+++ b/src/mysql-8/values.yml
@@ -55,6 +55,8 @@ containers:
 - name: app
   ports:
     - containerPort: 3306
+  cmd:
+    - --default-authentication-plugin=mysql_native_password
   cpu:
     request: 1000m
     limit: 1000m


### PR DESCRIPTION
Enable mysql_native_password for backwards compatibility.